### PR TITLE
chore: disable goreleaser release notes

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -19,8 +19,4 @@ checksum:
 snapshot:
   name_template: "{{ .Tag }}-next"
 changelog:
-  sort: asc
-  filters:
-    exclude:
-      - "^docs:"
-      - "^test:"
+  skip: true


### PR DESCRIPTION
- Release Notary is used instead