### PR TITLE
fix: make merge commit regex more lenient

### DIFF
--- a/pkg/text/is_merge_commit.go
+++ b/pkg/text/is_merge_commit.go
@@ -4,24 +4,11 @@ import (
 	"regexp"
 )
 
-var mergeCommitRegex = regexp.MustCompile(`^Merge commit '(?P<hash>\S+)'`)
-var mergeBranchRegex = regexp.MustCompile(`^Merge branch '(?P<incoming>\w+)' into (?P<current>\S+)`)
-var mergePRRegex = regexp.MustCompile(`^Merge pull request (?P<incoming>#\d+) from (?P<current>\S+)`)
-var kodiakMergeBranchRegex = regexp.MustCompile(`^Merge (?P<incoming>\w+) into (?P<current>\S+)`)
+var mergeCommitRegex = regexp.MustCompile(`^Merge .+`)
 
 // IsMergeCommit tests message string against expected format of a merge commit and returns true/false based on it
 func IsMergeCommit(message string) bool {
 	mergeCommitMatch := mergeCommitRegex.FindStringSubmatch(message)
 
-	mergeBranchMatch := mergeBranchRegex.FindStringSubmatch(message)
-
-	mergePRMatch := mergePRRegex.FindStringSubmatch(message)
-
-	kodiakMergeBranchMatch := kodiakMergeBranchRegex.FindStringSubmatch(message)
-
-	if mergeCommitMatch != nil || mergeBranchMatch != nil || mergePRMatch != nil || kodiakMergeBranchMatch != nil {
-		return true
-	}
-
-	return false
+	return mergeCommitMatch != nil
 }


### PR DESCRIPTION
- in order to make maintenance easier it would be better to make merge message regex lenient

Closes #101