### PR TITLE
chore: remove CNAME file

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,1 +1,0 @@
-commitsar.tech


### PR DESCRIPTION
We no longer use Github pages, so this file is not needed.