### PR TITLE
feat: introduce dispatcher package

### DIFF
--- a/internal/dispatcher/dispatcher.go
+++ b/internal/dispatcher/dispatcher.go
@@ -1,0 +1,62 @@
+package dispatcher
+
+import (
+	"io/ioutil"
+	"log"
+	"runtime"
+	"sync"
+)
+
+// Dispatcher is the central place which runs Pipelines. maxWorkers is based by default on number of CPUs * 2 accounting for modern CPU architectures.
+type Dispatcher struct {
+	debugLogger *log.Logger
+	maxWorkers  int
+}
+
+// Results contains the aggregated results of both the succesful and error pipelines.
+type Results struct {
+	SuccessfulPipelines []PipelineSuccess
+	Errors              []PipelineError
+}
+
+// New returns a set up instance of Dispatcher
+func New(debugLogger *log.Logger) *Dispatcher {
+	if debugLogger == nil {
+		debugLogger = log.New(ioutil.Discard, "", 0)
+	}
+
+	return &Dispatcher{debugLogger: debugLogger, maxWorkers: runtime.NumCPU() * 2}
+}
+
+// RunPipelines will run asynchronously all pipelines passed to it. It is limited only by the maxWorkers field on Dispatcher.
+func (dispatch *Dispatcher) RunPipelines(pipelines []Pipeliner) *Results {
+	// pipelineChannel is limited to the amount of CPU to prevent overloading the machie
+	pipelineChannel := make(chan Pipeliner, dispatch.maxWorkers)
+	successChannel := make(chan PipelineSuccess, 10)
+	errChannel := make(chan PipelineError, 10)
+	results := &Results{}
+
+	var wg sync.WaitGroup
+
+	wg.Add(1)
+	go func() {
+		for _, pipeline := range pipelines {
+			pipelineChannel <- pipeline
+		}
+		close(pipelineChannel)
+		wg.Done()
+	}()
+
+	wg.Add(1)
+	go dispatch.handleSuccess(&wg, successChannel, results)
+
+	wg.Add(1)
+	go dispatch.handleErrors(&wg, errChannel, results)
+
+	wg.Add(1)
+	go dispatch.work(&wg, pipelineChannel, successChannel, errChannel)
+
+	wg.Wait()
+
+	return results
+}

--- a/internal/dispatcher/dispatcher_test.go
+++ b/internal/dispatcher/dispatcher_test.go
@@ -1,0 +1,53 @@
+package dispatcher
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDispatcher(t *testing.T) {
+	dispatcher := New(nil)
+	dispatcher.maxWorkers = 1
+
+	pipelines := []Pipeliner{TestPipeline{TestName: "pipeline1", TestFn: successPipeline}}
+
+	results := dispatcher.RunPipelines(pipelines)
+
+	assert.Equal(t, "pipeline1", results.SuccessfulPipelines[0].PipelineName)
+	assert.Equal(t, "It succeeded", results.SuccessfulPipelines[0].Message)
+
+	pipelines2 := []Pipeliner{TestPipeline{TestName: "pipeline1", TestFn: successPipeline}, TestPipeline{TestName: "pipeline2", TestFn: failPipeline}, TestPipeline{TestName: "pipeline3", TestFn: failPipeline}, TestPipeline{TestName: "pipeline4", TestFn: successPipeline}}
+
+	results2 := dispatcher.RunPipelines(pipelines2)
+
+	assert.Equal(t, 2, len(results2.SuccessfulPipelines))
+	assert.Equal(t, 2, len(results2.Errors))
+}
+
+type TestPipeline struct {
+	TestName string
+	TestFn   func(chan PipelineError) *PipelineSuccess
+}
+
+func (p TestPipeline) Name() string {
+	return p.TestName
+}
+
+func (p TestPipeline) Run(errChannel chan PipelineError) *PipelineSuccess {
+	return p.TestFn(errChannel)
+}
+
+func successPipeline(chan PipelineError) *PipelineSuccess {
+	return &PipelineSuccess{
+		PipelineName: "pipeline1",
+		Message:      "It succeeded",
+	}
+}
+
+func failPipeline(errChan chan PipelineError) *PipelineSuccess {
+	errChan <- PipelineError{PipelineName: "pipeline2", Data: []FailureData{{Name: "test", Value: "test2"}}, Error: errors.New("some error")}
+
+	return nil
+}

--- a/internal/dispatcher/handle_errors.go
+++ b/internal/dispatcher/handle_errors.go
@@ -1,0 +1,17 @@
+package dispatcher
+
+import "sync"
+
+func (dispatch *Dispatcher) handleErrors(
+	wg *sync.WaitGroup,
+	channel <-chan PipelineError,
+	results *Results,
+) {
+	defer wg.Done()
+
+	for message := range channel {
+		dispatch.debugLogger.Printf("[%s] %s", message.PipelineName, message.Error)
+
+		results.Errors = append(results.Errors, message)
+	}
+}

--- a/internal/dispatcher/pipeline.go
+++ b/internal/dispatcher/pipeline.go
@@ -1,0 +1,27 @@
+package dispatcher
+
+// Pipeliner interface describes the requirements for pipelines the dispatcher can run
+type Pipeliner interface {
+	Name() string
+	Run(chan PipelineError) *PipelineSuccess
+}
+
+// FailureData is used to build the table output
+// Example: "hash": "somehash". It is built as a struct to enforce order
+type FailureData struct {
+	Name  string
+	Value string
+}
+
+// PipelineSuccess is returned by a pipeline if it encounters no errors
+type PipelineSuccess struct {
+	PipelineName string
+	Message      string
+}
+
+// PipelineError is used to group errors based on PipelineName
+type PipelineError struct {
+	PipelineName string
+	Data         []FailureData
+	Error        error
+}

--- a/internal/dispatcher/success_handler.go
+++ b/internal/dispatcher/success_handler.go
@@ -1,0 +1,17 @@
+package dispatcher
+
+import "sync"
+
+func (dispatch *Dispatcher) handleSuccess(
+	wg *sync.WaitGroup,
+	channel <-chan PipelineSuccess,
+	results *Results,
+) {
+	defer wg.Done()
+
+	for message := range channel {
+		dispatch.debugLogger.Printf("[%s] %s", message.PipelineName, message.Message)
+
+		results.SuccessfulPipelines = append(results.SuccessfulPipelines, message)
+	}
+}

--- a/internal/dispatcher/work.go
+++ b/internal/dispatcher/work.go
@@ -1,0 +1,31 @@
+package dispatcher
+
+import "sync"
+
+func (dispatch *Dispatcher) work(
+	wg *sync.WaitGroup,
+	pipelineChannel chan Pipeliner,
+	successChan chan PipelineSuccess,
+	errorChannel chan PipelineError,
+) {
+	defer wg.Done()
+	defer close(successChan)
+	defer close(errorChannel)
+
+	for {
+		pipeline, more := <-pipelineChannel
+
+		if more {
+			dispatch.debugLogger.Printf("Starting pipeline: %s", pipeline.Name())
+			success := pipeline.Run(errorChannel)
+
+			if success != nil {
+				successChan <- *success
+			}
+		} else {
+			dispatch.debugLogger.Print("All pipelines complete")
+			return
+		}
+	}
+
+}


### PR DESCRIPTION
This package serves as a starting point to rebuild each part of root_runner into a pipeline allowing for more modularity going forward.