### PR TITLE
Add commit pipeline under experimental flag

### DIFF
--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -35,3 +35,24 @@ jobs:
         uses: docker://reviewdog/action-golangci-lint
         with:
           github_token: ${{ secrets.github_token }}
+
+  validate-commits-experimental:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up Go 1.13
+        uses: actions/setup-go@v1
+        with:
+          go-version: 1.13
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@v1
+        # with:
+        #   fetch-depth: 20
+      - uses: actions/cache@v2
+        with:
+          path: ~/go/pkg/mod
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
+      - run: go mod download
+      - name: Run Commitsar
+        run: go run main.go experimental

--- a/internal/pipelines/commit_pipeline/docs.go
+++ b/internal/pipelines/commit_pipeline/docs.go
@@ -1,0 +1,4 @@
+/*Package commitpipeline is used to run analysis on commits
+All logic regarding getting commits is housed here.
+*/
+package commitpipeline

--- a/internal/pipelines/commit_pipeline/get_commits.go
+++ b/internal/pipelines/commit_pipeline/get_commits.go
@@ -1,0 +1,73 @@
+package commitpipeline
+
+import (
+	history "github.com/aevea/git/v2"
+	"github.com/aevea/integrations"
+)
+
+func (pipeline *CommitPipeline) getCommits(gitRepo *history.Git) ([]history.SimpleCommit, error) {
+	currentBranch := integrations.GetCurrentRef()
+
+	if currentBranch == "" {
+		gitBranch, err := gitRepo.CurrentBranch()
+
+		if err != nil {
+			return nil, err
+		}
+
+		currentBranch = gitBranch.Name().String()
+	}
+
+	pipeline.debugLogger.Printf("current branch %s", currentBranch)
+
+	upstreamBranch := integrations.FindCompareBranch()
+
+	if upstreamBranch == "" {
+		upstreamBranch = "master"
+	}
+
+	pipeline.debugLogger.Printf("upstream branch %s", upstreamBranch)
+
+	currentBranchCommit, err := gitRepo.LatestCommitOnBranch(currentBranch)
+
+	if err != nil {
+		return nil, err
+	}
+
+	currentBranchCommits, err := gitRepo.CommitsOnBranchSimple(currentBranchCommit.Hash)
+
+	if err != nil {
+		return nil, err
+	}
+
+	upstreamBranchCommit, err := gitRepo.LatestCommitOnBranch(upstreamBranch)
+
+	if err != nil {
+		return nil, err
+	}
+
+	upstreamBranchCommits, err := gitRepo.CommitsOnBranchSimple(upstreamBranchCommit.Hash)
+
+	if err != nil {
+		return nil, err
+	}
+
+	var diffedCommits []history.SimpleCommit
+
+	for _, commit := range currentBranchCommits {
+		if !contains(upstreamBranchCommits, commit) {
+			diffedCommits = append(diffedCommits, commit)
+		}
+	}
+
+	return diffedCommits, nil
+}
+
+func contains(s []history.SimpleCommit, e history.SimpleCommit) bool {
+	for _, a := range s {
+		if a.Hash == e.Hash {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/pipelines/commit_pipeline/name.go
+++ b/internal/pipelines/commit_pipeline/name.go
@@ -1,0 +1,5 @@
+package commitpipeline
+
+func (*CommitPipeline) Name() string {
+	return "commitpipeline"
+}

--- a/internal/pipelines/commit_pipeline/pipeline.go
+++ b/internal/pipelines/commit_pipeline/pipeline.go
@@ -1,0 +1,20 @@
+package commitpipeline
+
+import (
+	"io/ioutil"
+	"log"
+)
+
+// CommitPipeline is used to run checks in commits
+type CommitPipeline struct {
+	debugLogger *log.Logger
+}
+
+// New returns a setup instance of the CommitPipeline
+func New(debugLogger *log.Logger) *CommitPipeline {
+	if debugLogger == nil {
+		debugLogger = log.New(ioutil.Discard, "", 0)
+	}
+
+	return &CommitPipeline{debugLogger: debugLogger}
+}

--- a/internal/pipelines/commit_pipeline/run.go
+++ b/internal/pipelines/commit_pipeline/run.go
@@ -1,0 +1,50 @@
+package commitpipeline
+
+import (
+	"github.com/aevea/commitsar/internal/dispatcher"
+	"github.com/aevea/commitsar/pkg/text"
+	history "github.com/aevea/git/v2"
+	"github.com/aevea/quoad"
+)
+
+// Run runs the CommitPipeline pushing errors to the errChannel or returning the successMessage
+func (pipeline *CommitPipeline) Run(errChannel chan dispatcher.PipelineError) *dispatcher.PipelineSuccess {
+
+	gitRepo, err := history.OpenGit(".", pipeline.debugLogger)
+
+	if err != nil {
+		errChannel <- dispatcher.PipelineError{
+			PipelineName: "commit",
+			Error:        err,
+		}
+		return nil
+	}
+
+	commits, err := pipeline.getCommits(gitRepo)
+
+	if err != nil {
+		errChannel <- dispatcher.PipelineError{
+			PipelineName: "commit",
+			Error:        err,
+		}
+		return nil
+	}
+
+	for _, commit := range commits {
+		parsedCommit := quoad.ParseCommitMessage(commit.Message)
+
+		textErr := text.CheckMessageTitle(parsedCommit, true)
+
+		if textErr != nil {
+			errChannel <- dispatcher.PipelineError{
+				PipelineName: pipeline.Name(),
+				Data: []dispatcher.FailureData{
+					{Name: "Commit", Value: parsedCommit.Heading},
+				},
+				Error: textErr,
+			}
+		}
+	}
+
+	return nil
+}

--- a/main.go
+++ b/main.go
@@ -136,7 +136,7 @@ func main() {
 		Short: "Print the version number of Commitsar",
 		Long:  `All software has versions. This is Commitsars.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			debugLogger := log.New(os.Stdout, "[DEBUG]", 0)
+			debugLogger := log.New(os.Stdout, "[DEBUG] ", 0)
 
 			var pipelines []dispatcher.Pipeliner
 

--- a/main.go
+++ b/main.go
@@ -7,6 +7,8 @@ import (
 	"os"
 
 	"github.com/aevea/commitsar/config"
+	"github.com/aevea/commitsar/internal/dispatcher"
+	commitpipeline "github.com/aevea/commitsar/internal/pipelines/commit_pipeline"
 	"github.com/aevea/commitsar/internal/version_runner"
 	"github.com/logrusorgru/aurora"
 
@@ -128,6 +130,31 @@ func main() {
 	}
 
 	rootCmd.AddCommand(versionCmd)
+
+	var experimentalCmd = &cobra.Command{
+		Use:   "experimental",
+		Short: "Print the version number of Commitsar",
+		Long:  `All software has versions. This is Commitsars.`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			debugLogger := log.New(os.Stdout, "[DEBUG]", 0)
+
+			var pipelines []dispatcher.Pipeliner
+
+			runner := dispatcher.New(debugLogger)
+
+			pipeline := commitpipeline.New(debugLogger)
+
+			pipelines = append(pipelines, pipeline)
+
+			results := runner.RunPipelines(pipelines)
+
+			log.Println(results)
+
+			return nil
+		},
+	}
+
+	rootCmd.AddCommand(experimentalCmd)
 
 	if err := rootCmd.Execute(); err != nil {
 		fmt.Println(aurora.Red(err))


### PR DESCRIPTION
As part of the rewrite to make commitsar more extensible the main runner needs to be updated to run pipelines brought in #263. Right now it is hidden under the experimental command until deemed stable enough.

This PR adds:
- experimental command
- documentation for commands
- extra CI set up to verify that it works when proper commit objects are not available