### PR TITLE
feat: add required-scopes option for stricter scope validations

### DIFF
--- a/config/commits.go
+++ b/config/commits.go
@@ -11,6 +11,7 @@ func CommitConfig() root_runner.RunnerOptions {
 	strict := true
 	limit := 0
 	all := false
+	requiredScopes := []string{}
 
 	if viper.IsSet("commits.strict") {
 		strict = viper.GetBool("commits.strict")
@@ -24,9 +25,14 @@ func CommitConfig() root_runner.RunnerOptions {
 		all = viper.GetBool("commits.all")
 	}
 
+	if viper.IsSet("commits.required-scopes") {
+		requiredScopes = viper.GetStringSlice("commits.required-scopes")
+	}
+
 	return root_runner.RunnerOptions{
-		Strict:     strict,
-		Limit:      limit,
-		AllCommits: all,
+		Strict:         strict,
+		Limit:          limit,
+		AllCommits:     all,
+		RequiredScopes: requiredScopes,
 	}
 }

--- a/config/commits_test.go
+++ b/config/commits_test.go
@@ -15,6 +15,7 @@ func TestCommitConfig(t *testing.T) {
 	assert.Equal(t, true, defaultConfig.Strict, "expect strict to be true by default")
 	assert.Equal(t, 0, defaultConfig.Limit, "expect the limit to be 0 by default")
 	assert.Equal(t, false, defaultConfig.AllCommits, "expect AllCommits to be true by default")
+	assert.Equal(t, []string{}, defaultConfig.RequiredScopes, "expect required scopes to be empty slice by default")
 
 	err := os.Setenv(CommitsarConfigPath, "./testdata")
 	assert.NoError(t, err)
@@ -27,6 +28,7 @@ func TestCommitConfig(t *testing.T) {
 	assert.Equal(t, false, commitConfig.Strict, "expect strict to be false as opposed to the default of true")
 	assert.Equal(t, 100, commitConfig.Limit, "expect limit to be 100 as opposed to the default of 0")
 	assert.Equal(t, true, commitConfig.AllCommits, "expect strict to be false as opposed to the default of false")
+	assert.Equal(t, []string{}, commitConfig.RequiredScopes, "expect required scopes to be empty slice same as default for backward compatibility")
 
 	os.Clearenv()
 

--- a/internal/commitpipeline/pipeline.go
+++ b/internal/commitpipeline/pipeline.go
@@ -23,6 +23,8 @@ type Options struct {
 	// AllCommits will check all the commits on the upstream branch. Regardless of Limit setting.
 	AllCommits bool
 	Strict     bool
+	// RequiredScopes will check scope in commit message against list of required ones
+	RequiredScopes []string
 }
 
 func New(logger, debugLogger *log.Logger, options *Options, args ...string) (*Pipeline, error) {

--- a/internal/root_runner/root_runner.go
+++ b/internal/root_runner/root_runner.go
@@ -23,6 +23,8 @@ type RunnerOptions struct {
 	// AllCommits will check all the commits on the upstream branch. Regardless of Limit setting.
 	AllCommits bool
 	Strict     bool
+	// RequiredScopes will check scope in commit message against list of required ones
+	RequiredScopes []string
 }
 
 // New returns a new instance of a RootRunner with fallback for logging

--- a/internal/root_runner/run.go
+++ b/internal/root_runner/run.go
@@ -22,6 +22,7 @@ func (runner *Runner) Run(options RunnerOptions, args ...string) error {
 			Path:           options.Path,
 			Strict:         options.Strict,
 			UpstreamBranch: options.UpstreamBranch,
+			RequiredScopes: options.RequiredScopes,
 		}
 
 		commitPipe, err := commitpipeline.New(runner.Logger, runner.DebugLogger, &commitOptions, args...)

--- a/main.go
+++ b/main.go
@@ -66,6 +66,11 @@ func bindRootFlags(rootCmd *cobra.Command) error {
 	if err != nil {
 		return err
 	}
+	rootCmd.Flags().StringSlice("required-scopes", nil, "forces scope to match one of the provided values")
+	err = viper.BindPFlag("commits.required-scopes", rootCmd.Flags().Lookup("required-scopes"))
+	if err != nil {
+		return err
+	}
 
 	// Not used. TODO: Documentation
 	rootCmd.Flags().StringP("path", "d", ".", "dir points to the path of the repository")

--- a/pkg/text/check_required_scopes.go
+++ b/pkg/text/check_required_scopes.go
@@ -1,0 +1,25 @@
+package text
+
+import (
+	"errors"
+)
+
+var errMissingRequiredScope = errors.New("required scope missing")
+
+// RequiredScopeChecker creates case sensitive strict checker, validating that
+// provided scope matches one from required scopes list
+func RequiredScopeChecker(requiredScopes []string) func(string) error {
+	return func(scope string) error {
+		if len(requiredScopes) < 1 {
+			return nil
+		}
+
+		for _, rs := range requiredScopes {
+			if scope == rs {
+				return nil
+			}
+		}
+
+		return errMissingRequiredScope
+	}
+}

--- a/pkg/text/check_required_scopes_test.go
+++ b/pkg/text/check_required_scopes_test.go
@@ -1,0 +1,36 @@
+package text
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRequiredScopesChecker(t *testing.T) {
+	tests := map[error][]struct {
+		scope          string
+		requiredScopes []string
+	}{
+		nil: {
+			{"ci", []string{}},
+			{"ui", nil},
+			{"ci", []string{"ci", "project-1", "repo", "ui"}},
+			{"ci", []string{"ui", "project-1", "repo", "ci"}},
+			{"repo", []string{"repo"}},
+		},
+		errMissingRequiredScope: {
+			{"SECURITY", []string{"security", "ci", "ui"}},
+			{"SeCuRiTy", []string{"security", "ci", "ui"}},
+			{"sth", []string{"security", "ci", "ui"}},
+			{"se curity", []string{"security", "ci", "ui"}},
+			{"", []string{"repo"}},
+		},
+	}
+
+	for expected, testCases := range tests {
+		for _, testCase := range testCases {
+			err := RequiredScopeChecker(testCase.requiredScopes)(testCase.scope)
+			assert.Equal(t, expected, err)
+		}
+	}
+}


### PR DESCRIPTION
hey @fallion, I've tried to keep those changes minimal and aligned with coding conventions - happy to make further adjustments if needed.

Some discussion items:

- `r` seems like a weak shorthand for `required-scopes`, but since it's required to be the single letter I didn't come up with anything better, wdyt?
- I decided to go with a single option being a list of required scopes. This addition is backward compatible. It could be done with multiple config values, fe. one enforcing scope and other listing allowed ones, but IMO single config makes more sense
- initially, I've added dynamic formatting of error (listing all required-scopes that did not match) in the check results table, but since that can break formatting in case of longer required-scopes lists - I've made a fallback to the static error message. Do we need a hint for end-users, like printing all required scopes f.e. right after `Starting analysis...`
- I intentionally avoided modification of `CheckMessageTitle` as requiring scope matches is an additional feature I believe. That makes 2 possible errors for a commit to occur, one from the new check I added and one from  CheckMessageTitle. For now only first error coming from `CheckMessageTitle` is formatted and displayed in the table. Should we display both errors formatted with a newline, wdyt?

resolves #325 