### PR TITLE
fix(www): make GitHub link point to this repo

### DIFF
--- a/www/docusaurus.config.js
+++ b/www/docusaurus.config.js
@@ -22,7 +22,7 @@ module.exports = {
         },
         // { to: "blog", label: "Blog", position: "left" },
         {
-          href: "https://github.com/facebook/docusaurus",
+          href: "https://github.com/aevea/commitsar",
           label: "GitHub",
           position: "right",
         },


### PR DESCRIPTION
It was pointing to Docusaurus' otherwise.