### PR TITLE
feat(config): add commits.upstreamBranch option

### DIFF
--- a/config/commits.go
+++ b/config/commits.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"github.com/aevea/commitsar/internal/root_runner"
+	"github.com/aevea/integrations"
 	"github.com/spf13/viper"
 )
 
@@ -11,6 +12,7 @@ func CommitConfig() root_runner.RunnerOptions {
 	strict := true
 	limit := 0
 	all := false
+	upstreamBranch := integrations.FindCompareBranch()
 	requiredScopes := []string{}
 
 	if viper.IsSet("commits.strict") {
@@ -25,6 +27,10 @@ func CommitConfig() root_runner.RunnerOptions {
 		all = viper.GetBool("commits.all")
 	}
 
+	if viper.IsSet("commits.upstreamBranch") {
+		upstreamBranch = viper.GetString("commits.upstreamBranch")
+	}
+
 	if viper.IsSet("commits.required-scopes") {
 		requiredScopes = viper.GetStringSlice("commits.required-scopes")
 	}
@@ -33,6 +39,7 @@ func CommitConfig() root_runner.RunnerOptions {
 		Strict:         strict,
 		Limit:          limit,
 		AllCommits:     all,
+		UpstreamBranch: upstreamBranch,
 		RequiredScopes: requiredScopes,
 	}
 }

--- a/config/commits_test.go
+++ b/config/commits_test.go
@@ -15,6 +15,7 @@ func TestCommitConfig(t *testing.T) {
 	assert.Equal(t, true, defaultConfig.Strict, "expect strict to be true by default")
 	assert.Equal(t, 0, defaultConfig.Limit, "expect the limit to be 0 by default")
 	assert.Equal(t, false, defaultConfig.AllCommits, "expect AllCommits to be true by default")
+	assert.Equal(t, "origin/master", defaultConfig.UpstreamBranch, "expect UpstreamBranch to be origin/master by default")
 	assert.Equal(t, []string{}, defaultConfig.RequiredScopes, "expect required scopes to be empty slice by default")
 
 	err := os.Setenv(CommitsarConfigPath, "./testdata")
@@ -28,6 +29,7 @@ func TestCommitConfig(t *testing.T) {
 	assert.Equal(t, false, commitConfig.Strict, "expect strict to be false as opposed to the default of true")
 	assert.Equal(t, 100, commitConfig.Limit, "expect limit to be 100 as opposed to the default of 0")
 	assert.Equal(t, true, commitConfig.AllCommits, "expect strict to be false as opposed to the default of false")
+	assert.Equal(t, "origin/main", commitConfig.UpstreamBranch, "expect UpstreamBranch to be origin/main as opposed to the default of origin/master")
 	assert.Equal(t, []string{}, commitConfig.RequiredScopes, "expect required scopes to be empty slice same as default for backward compatibility")
 
 	os.Clearenv()

--- a/config/testdata/.commitsar.yaml
+++ b/config/testdata/.commitsar.yaml
@@ -3,3 +3,4 @@ commits:
   strict: false
   limit: 100
   all: true
+  upstreamBranch: origin/main

--- a/main.go
+++ b/main.go
@@ -9,7 +9,6 @@ import (
 	"github.com/logrusorgru/aurora"
 
 	"github.com/aevea/commitsar/internal/root_runner"
-	"github.com/aevea/integrations"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 
@@ -27,7 +26,6 @@ var commit string
 var date string
 
 func runRoot(cmd *cobra.Command, args []string) error {
-	upstreamBranch := integrations.FindCompareBranch()
 	if viper.GetBool("verbose") {
 		log.SetLevel(log.DebugLevel)
 	}
@@ -35,8 +33,6 @@ func runRoot(cmd *cobra.Command, args []string) error {
 	runner := root_runner.New()
 
 	commitConfig := config.CommitConfig()
-
-	commitConfig.UpstreamBranch = upstreamBranch
 
 	commitConfig.Path = "."
 

--- a/www/docs/configuration/config-file.md
+++ b/www/docs/configuration/config-file.md
@@ -35,14 +35,16 @@ commits:
   strict: true
   limit: 0
   all: false
+  upstreamBranch: origin/master
 ```
 
-| Name     | Default Value | Description                                                                                   | Available from |
-| -------- | ------------- | --------------------------------------------------------------------------------------------- | -------------- |
-| disabled | false         | Disables checking commmits. Useful if you want to use commitsar only for PR titles.           | v0.14.0        |
-| strict   | true          | Enforces strict category enforcement.                                                         | v0.14.0        |
-| limit    | none          | Makes commitsar check only the last x commits. Useful if you want to run commitsar on master. | v0.14.0        |
-| all      | false         | Makes commitsar check all the commits in history. **Overrides the `limit` flag**              | v0.14.0        |
+| Name           | Default Value | Description                                                                                             | Available from |
+| -------------- | ------------- | ------------------------------------------------------------------------------------------------------- | -------------- |
+| disabled       | false         | Disables checking commmits. Useful if you want to use commitsar only for PR titles.                     | v0.14.0        |
+| strict         | true          | Enforces strict category enforcement.                                                                   | v0.14.0        |
+| limit          | none          | Makes commitsar check only the last x commits. Useful if you want to run commitsar on master.           | v0.14.0        |
+| all            | false         | Makes commitsar check all the commits in history. **Overrides the `limit` flag**                        | v0.14.0        |
+| upstreamBranch | origin/master | Makes commitsar check against specific branch (e.g. use `origin/main` if `main` is your default branch) | v0.17.0        |
 
 ## Pull Request style settings
 


### PR DESCRIPTION
The default is still `origin/master` as given by
github.com/aevea/integrations's FindCompareBranch,
but it is now possible to use
```yaml
commits:
  upstreamBranch: origin/main
```
in your `.commitsar.yaml` config file to target
`origin/main` as upstream branch.

It does not quite fix the following related issue
as it proposed to have both `origin/master` and
`origin/main` as default upstream branches, but
it at least offers to configure the upstream
branch as a first step.

Related issue: https://github.com/aevea/commitsar/issues/317