### PR TITLE
feat: allow setting path of repoistory

### DIFF
--- a/docs/content/usage/binary.md
+++ b/docs/content/usage/binary.md
@@ -10,3 +10,9 @@ Adjust for version and distribution. Please check [Releases](https://github.com/
 - tar -xzf commitsar_v0.0.2_Linux_x86_64.tar.gz
 - ./commitsar
 ```
+
+```sh
+- curl -L -O https://github.com/aevea/commitsar/releases/download/v0.0.2/commitsar_v0.0.2_Linux_x86_64.tar.gz
+- tar -xzf commitsar_v0.0.2_Linux_x86_64.tar.gz
+- ./commitsar ./path-to-repo
+```

--- a/docs/content/usage/docker.md
+++ b/docs/content/usage/docker.md
@@ -6,7 +6,11 @@ title: Docker
 For running in docker just use the following command:
 
 ```sh
-docker run --rm --name="commitsar" -w /src -v "$(pwd)":/src aevea/commitsar
+docker run --rm --name="commitsar" -w /src -v "$(pwd)":/src aevea/commitsar 
 ```
 
-Make sure to load the working directory where `.git` folder is present. Commitsar will not work without the `.git` folder.
+```sh
+docker run --rm --name="commitsar" -w /src -v "$(pwd)":/src aevea/commitsar ./path-to-repo
+```
+
+Make sure to load the working directory where `.git` folder is present. Commitsar will not work without the `.git` folder. This can be overriden by setting the path argument.

--- a/docs/content/usage/gobinaries.md
+++ b/docs/content/usage/gobinaries.md
@@ -3,7 +3,7 @@ id: gobinaries
 title: GoBinaries
 ---
 
-Running using <https://gobinaries.com/>
+Install commitsar on your machine using <https://gobinaries.com/>
 
 ```sh
 curl -sf https://gobinaries.com/aevea/commitsar | sh
@@ -13,4 +13,15 @@ Or a specific version:
 
 ```sh
 curl -sf https://gobinaries.com/aevea/commitsar[@VERSION] | sh
+```
+
+**To use:**
+
+```sh
+commitsar
+```
+
+Or with a path:
+```sh
+commitsar ./path-to-repo
 ```

--- a/main.go
+++ b/main.go
@@ -36,6 +36,10 @@ func runRoot(cmd *cobra.Command, args []string) error {
 
 	commitConfig.Path = "."
 
+	if len(args) > 0 {
+		commitConfig.Path = args[0]
+	}
+
 	return runner.Run(commitConfig, args...)
 }
 


### PR DESCRIPTION
This will allow more fluid usage of commitsar as the user will be able to specify a specific repo path.

Closes #35