### PR TITLE
feat: allow revert commits

### DIFF
--- a/internal/commitpipeline/run.go
+++ b/internal/commitpipeline/run.go
@@ -59,7 +59,7 @@ func (pipeline *Pipeline) Run() (*dispatcher.PipelineSuccess, error) {
 
 		log.Debugf("Commit found: [hash] %v [message] %v", parsedCommit.Hash.String(), parsedCommit.Heading)
 
-		if !text.IsMergeCommit(commitObject.Message) && !text.IsInitialCommit(commitObject.Message) {
+		if !text.IsMergeCommit(commitObject.Message) && !text.IsInitialCommit(commitObject.Message) && !text.IsRevertCommit(commitObject.Message) {
 			filteredCommits = append(filteredCommits, commitHash)
 		}
 	}

--- a/pkg/text/is_revert_commit.go
+++ b/pkg/text/is_revert_commit.go
@@ -1,0 +1,11 @@
+package text
+
+import "strings"
+
+func IsRevertCommit(commitMessage string) bool {
+	if strings.HasPrefix(commitMessage, "Revert") {
+		return true
+	}
+
+	return strings.HasPrefix(commitMessage, "revert")
+}

--- a/pkg/text/is_revert_commit_test.go
+++ b/pkg/text/is_revert_commit_test.go
@@ -1,0 +1,22 @@
+package text
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIsRevertCommit(t *testing.T) {
+	tests := map[string]bool{
+		"Revert some commit":      true,
+		"revert \"some commit\"":  true,
+		"chore: something\n":      false,
+		"fix: test":               false,
+		"fix: Kodiak style regex": false,
+	}
+
+	for test, expected := range tests {
+		err := IsRevertCommit(test)
+		assert.Equal(t, expected, err)
+	}
+}


### PR DESCRIPTION
Previously Revert commits would fail the pipeline as they were not considered conventional commit friendly.
This caused issues in multiple projects as commitsar checks would just be ignored.

Closes #434