### PR TITLE
chore(goreleaser): remove archive string replacements

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -8,13 +8,6 @@ builds:
   - env:
       - CGO_ENABLED=0
     main: ./main.go
-archives:
-  - replacements:
-      darwin: Darwin
-      linux: Linux
-      windows: Windows
-      386: i386
-      amd64: x86_64
 checksum:
   name_template: "checksums.txt"
 snapshot:


### PR DESCRIPTION
by default go env vars already have sane values that we shouldn't override; tools that rely on the value of GOOS or GOARCH to resolve the binary name need additional tweaking in our repo because of those overrides we set up