### PR TITLE
fix(commit): wrong hash commit in log

### DIFF
--- a/internal/commitpipeline/run.go
+++ b/internal/commitpipeline/run.go
@@ -57,7 +57,7 @@ func (pipeline *Pipeline) Run() (*dispatcher.PipelineSuccess, error) {
 
 		parsedCommit := quoad.ParseCommitMessage(commitObject.Message)
 
-		log.Debugf("Commit found: [hash] %v [message] %v", parsedCommit.Hash.String(), parsedCommit.Heading)
+		log.Debugf("Commit found: [hash] %v [message] %v", commitObject.Hash, parsedCommit.Heading)
 
 		if !text.IsMergeCommit(commitObject.Message) && !text.IsInitialCommit(commitObject.Message) && !text.IsRevertCommit(commitObject.Message) {
 			filteredCommits = append(filteredCommits, commitHash)


### PR DESCRIPTION
All commit hash is wrong `0000000000000000000000000000000000000000`

![image](https://user-images.githubusercontent.com/11895605/227439917-a7f7eb95-bedd-4c2e-9b7b-e91a724ed004.png)

**fixed**
![image](https://user-images.githubusercontent.com/11895605/227440420-a56d1a75-2277-42e3-b2a6-83d88b4090a2.png)
