### PR TITLE
fix: correct the spelling of ConventionalStyle

### DIFF
--- a/internal/prpipeline/run.go
+++ b/internal/prpipeline/run.go
@@ -31,7 +31,7 @@ func (pipeline *Pipeline) Run() (*dispatcher.PipelineSuccess, error) {
 				Message:      aurora.Sprintf(aurora.Green("Success! Found the following JIRA issue references: %v"), references),
 			}, nil
 		}
-	case ConvetionalStyle:
+	case ConventionalStyle:
 		commit := quoad.ParseCommitMessage(*title)
 
 		err := text.CheckMessageTitle(commit, true)

--- a/internal/prpipeline/types.go
+++ b/internal/prpipeline/types.go
@@ -4,5 +4,5 @@ type PRStyle = string
 
 const (
 	JiraStyle        PRStyle = "jira"
-	ConvetionalStyle PRStyle = "conventional"
+	ConventionalStyle PRStyle = "conventional"
 )

--- a/internal/root_runner/run.go
+++ b/internal/root_runner/run.go
@@ -50,7 +50,7 @@ func (runner *Runner) Run(options RunnerOptions, args ...string) error {
 		}
 
 		if viper.IsSet("pull_request.conventional") {
-			prOptions.Style = prpipeline.ConvetionalStyle
+			prOptions.Style = prpipeline.ConventionalStyle
 		}
 
 		prPipe, err := prpipeline.New(prOptions)


### PR DESCRIPTION
I think that this is only an internal name, so will not effect external use (in configs or...).
So correcting the spelling should not cause pain.