### PR TITLE
fix(docker): build step was failing

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,6 +34,8 @@ COPY go.mod go.sum Makefile /app/
 RUN mise exec -- go mod download
 
 COPY . /app/
+# Fix git ownership issue
+RUN git config --global --add safe.directory /app
 RUN mise exec -- make build/docker
 
 FROM debian:13-slim

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ endef
 
 build/docker:
 	$(call prepare_build_vars)
-	CGO_ENABLED=0 go build -a -tags "osusergo netgo" --ldflags "${DATE_FLAG} ${VERSION_FLAG} ${COMMIT_FLAG} -linkmode external -extldflags '-static'" -o build/commitsar ./main.go
+	CGO_ENABLED=0 go build -a -tags "osusergo netgo" --ldflags "${DATE_FLAG} ${VERSION_FLAG} ${COMMIT_FLAG}" -o build/commitsar ./main.go
 
 build/local:
 	$(call prepare_build_vars)


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fixes Docker build failure by addressing git ownership issue and simplifying build command in `Makefile`.
> 
>   - **Dockerfile**:
>     - Adds `RUN git config --global --add safe.directory /app` to fix git ownership issue during build.
>   - **Makefile**:
>     - Removes `-linkmode external -extldflags '-static'` from `build/docker` target to simplify build command.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=aevea%2Fcommitsar&utm_source=github&utm_medium=referral)<sup> for 5350c17b9a8004b9633f14ad310779be013db767. You can [customize](https://app.ellipsis.dev/aevea/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->