### PR TITLE
fix(config): allow both conventional and jira styles

### DIFF
--- a/internal/prpipeline/pipeline.go
+++ b/internal/prpipeline/pipeline.go
@@ -3,8 +3,8 @@ package prpipeline
 type Options struct {
 	// Path to the git repository
 	Path string
-	// Style is the style of PR title to enforce
-	Style PRStyle
+	// Styles are the styles of PR title to enforce (can be multiple)
+	Styles []PRStyle
 	// Keys checks for required keys in the PR title
 	Keys []string
 }

--- a/internal/prpipeline/run_test.go
+++ b/internal/prpipeline/run_test.go
@@ -1,0 +1,188 @@
+package prpipeline
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestValidateTitle_ConventionalStyle_Success(t *testing.T) {
+	pipeline := &Pipeline{
+		options: Options{
+			Styles: []PRStyle{ConventionalStyle},
+		},
+	}
+
+	result, err := pipeline.validateTitle("feat: add new feature")
+
+	assert.NoError(t, err)
+	assert.NotNil(t, result)
+	assert.Contains(t, result.Message, "Success!")
+	assert.Contains(t, result.Message, "conventional commit")
+}
+
+func TestValidateTitle_ConventionalStyle_Failure(t *testing.T) {
+	pipeline := &Pipeline{
+		options: Options{
+			Styles: []PRStyle{ConventionalStyle},
+		},
+	}
+
+	result, err := pipeline.validateTitle("invalid title without category")
+
+	assert.Error(t, err)
+	assert.Nil(t, result)
+	assert.Contains(t, err.Error(), "validation failed")
+	assert.Contains(t, err.Error(), "category missing")
+}
+
+func TestValidateTitle_JiraStyle_Success(t *testing.T) {
+	pipeline := &Pipeline{
+		options: Options{
+			Styles: []PRStyle{JiraStyle},
+			Keys:   []string{"TEST"},
+		},
+	}
+
+	result, err := pipeline.validateTitle("TEST-123: add new feature")
+
+	assert.NoError(t, err)
+	assert.NotNil(t, result)
+	assert.Contains(t, result.Message, "Success!")
+	assert.Contains(t, result.Message, "JIRA issue references")
+}
+
+func TestValidateTitle_JiraStyle_Failure(t *testing.T) {
+	pipeline := &Pipeline{
+		options: Options{
+			Styles: []PRStyle{JiraStyle},
+			Keys:   []string{"TEST"},
+		},
+	}
+
+	result, err := pipeline.validateTitle("add new feature without jira")
+
+	assert.Error(t, err)
+	assert.Nil(t, result)
+	assert.Contains(t, err.Error(), "validation failed")
+	assert.Contains(t, err.Error(), "no JIRA issue references found")
+}
+
+func TestValidateTitle_BothStyles_Success(t *testing.T) {
+	pipeline := &Pipeline{
+		options: Options{
+			Styles: []PRStyle{ConventionalStyle, JiraStyle},
+			Keys:   []string{"TEST"},
+		},
+	}
+
+	result, err := pipeline.validateTitle("feat(TEST-123): add new feature")
+
+	assert.NoError(t, err)
+	assert.NotNil(t, result)
+	assert.Contains(t, result.Message, "Success!")
+	assert.Contains(t, result.Message, "conventional commit")
+	assert.Contains(t, result.Message, "JIRA issue references")
+}
+
+func TestValidateTitle_BothStyles_ConventionalFails(t *testing.T) {
+	pipeline := &Pipeline{
+		options: Options{
+			Styles: []PRStyle{ConventionalStyle, JiraStyle},
+			Keys:   []string{"TEST"},
+		},
+	}
+
+	result, err := pipeline.validateTitle("TEST-123: invalid title without category")
+
+	assert.Error(t, err)
+	assert.Nil(t, result)
+	assert.Contains(t, err.Error(), "validation failed")
+	assert.Contains(t, err.Error(), "category missing")
+}
+
+func TestValidateTitle_BothStyles_JiraFails(t *testing.T) {
+	pipeline := &Pipeline{
+		options: Options{
+			Styles: []PRStyle{ConventionalStyle, JiraStyle},
+			Keys:   []string{"TEST"},
+		},
+	}
+
+	result, err := pipeline.validateTitle("feat: add new feature without jira")
+
+	assert.Error(t, err)
+	assert.Nil(t, result)
+	assert.Contains(t, err.Error(), "validation failed")
+	assert.Contains(t, err.Error(), "no JIRA issue references found")
+}
+
+func TestValidateTitle_BothStyles_BothFail(t *testing.T) {
+	pipeline := &Pipeline{
+		options: Options{
+			Styles: []PRStyle{ConventionalStyle, JiraStyle},
+			Keys:   []string{"TEST"},
+		},
+	}
+
+	result, err := pipeline.validateTitle("invalid title without category or jira")
+
+	assert.Error(t, err)
+	assert.Nil(t, result)
+	assert.Contains(t, err.Error(), "validation failed")
+	// Should contain both error messages
+	errorMsg := err.Error()
+	assert.True(t, strings.Contains(errorMsg, "category missing") || strings.Contains(errorMsg, "no JIRA issue references found"))
+}
+
+func TestValidateTitle_NoStyles(t *testing.T) {
+	pipeline := &Pipeline{
+		options: Options{
+			Styles: []PRStyle{},
+		},
+	}
+
+	result, err := pipeline.validateTitle("any title")
+
+	assert.Error(t, err)
+	assert.Nil(t, result)
+	assert.Equal(t, "pr checking is configured, but no style has been chosen", err.Error())
+}
+
+func TestValidateTitle_ConventionalWithJiraInScope(t *testing.T) {
+	// Test the specific use case from the issue: feat(XXX-1234): This is the title
+	pipeline := &Pipeline{
+		options: Options{
+			Styles: []PRStyle{ConventionalStyle, JiraStyle},
+			Keys:   []string{"XXX"},
+		},
+	}
+
+	result, err := pipeline.validateTitle("feat(XXX-1234): This is the title")
+
+	assert.NoError(t, err)
+	assert.NotNil(t, result)
+	assert.Contains(t, result.Message, "Success!")
+	assert.Contains(t, result.Message, "conventional commit")
+	assert.Contains(t, result.Message, "JIRA issue references")
+}
+
+func TestValidateTitle_ConventionalWithJiraInTitle(t *testing.T) {
+	// Test with JIRA in the title part: feat: XXX-1234 This is the title
+	pipeline := &Pipeline{
+		options: Options{
+			Styles: []PRStyle{ConventionalStyle, JiraStyle},
+			Keys:   []string{"XXX"},
+		},
+	}
+
+	result, err := pipeline.validateTitle("feat: XXX-1234 This is the title")
+
+	assert.NoError(t, err)
+	assert.NotNil(t, result)
+	assert.Contains(t, result.Message, "Success!")
+	assert.Contains(t, result.Message, "conventional commit")
+	assert.Contains(t, result.Message, "JIRA issue references")
+}
+

--- a/internal/root_runner/run.go
+++ b/internal/root_runner/run.go
@@ -41,16 +41,17 @@ func (runner *Runner) Run(options RunnerOptions, args ...string) error {
 		log.Debug("PR pipeline")
 
 		prOptions := prpipeline.Options{
-			Path: options.Path,
+			Path:   options.Path,
+			Styles: []prpipeline.PRStyle{},
 		}
 
 		if viper.IsSet("pull_request.jira_title") {
-			prOptions.Style = prpipeline.JiraStyle
+			prOptions.Styles = append(prOptions.Styles, prpipeline.JiraStyle)
 			prOptions.Keys = viper.GetStringSlice("pull_request.jira_keys")
 		}
 
 		if viper.IsSet("pull_request.conventional") {
-			prOptions.Style = prpipeline.ConventionalStyle
+			prOptions.Styles = append(prOptions.Styles, prpipeline.ConventionalStyle)
 		}
 
 		prPipe, err := prpipeline.New(prOptions)

--- a/internal/root_runner/run_test.go
+++ b/internal/root_runner/run_test.go
@@ -91,3 +91,106 @@ func TestMissingPipelines(t *testing.T) {
 
 	viper.Set("commits.disabled", "")
 }
+
+func TestPRPipeline_ConventionalOnly(t *testing.T) {
+	handler := memory.New()
+
+	log.SetHandler(handler)
+
+	runner := Runner{}
+
+	viper.Set("commits.disabled", true)
+	viper.Set("pull_request.conventional", true)
+
+	// This will fail because it needs GitHub API access, but we can verify the pipeline is created
+	err := runner.Run(RunnerOptions{})
+
+	// Should fail due to missing GitHub env vars, not due to missing pipeline
+	assert.Error(t, err)
+	assert.NotEqual(t, "no pipelines defined", err.Error())
+
+	viper.Set("commits.disabled", "")
+	viper.Set("pull_request.conventional", "")
+}
+
+func TestPRPipeline_JiraOnly(t *testing.T) {
+	handler := memory.New()
+
+	log.SetHandler(handler)
+
+	runner := Runner{}
+
+	viper.Set("commits.disabled", true)
+	viper.Set("pull_request.jira_title", true)
+
+	// This will fail because it needs GitHub API access, but we can verify the pipeline is created
+	err := runner.Run(RunnerOptions{})
+
+	// Should fail due to missing GitHub env vars, not due to missing pipeline
+	assert.Error(t, err)
+	assert.NotEqual(t, "no pipelines defined", err.Error())
+
+	viper.Set("commits.disabled", "")
+	viper.Set("pull_request.jira_title", "")
+}
+
+func TestPRPipeline_BothStyles(t *testing.T) {
+	handler := memory.New()
+
+	log.SetHandler(handler)
+
+	runner := Runner{}
+
+	viper.Set("commits.disabled", true)
+	viper.Set("pull_request.conventional", true)
+	viper.Set("pull_request.jira_title", true)
+	viper.Set("pull_request.jira_keys", []string{"TEST"})
+
+	// This will fail because it needs GitHub API access, but we can verify the pipeline is created
+	err := runner.Run(RunnerOptions{})
+
+	// Should fail due to missing GitHub env vars, not due to missing pipeline
+	assert.Error(t, err)
+	assert.NotEqual(t, "no pipelines defined", err.Error())
+
+	viper.Set("commits.disabled", "")
+	viper.Set("pull_request.conventional", "")
+	viper.Set("pull_request.jira_title", "")
+	viper.Set("pull_request.jira_keys", "")
+}
+
+func TestPRPipeline_OptionsConfiguration(t *testing.T) {
+	// Test that when both styles are configured, both are added to the Options
+	viper.Reset()
+	viper.Set("pull_request.conventional", true)
+	viper.Set("pull_request.jira_title", true)
+	viper.Set("pull_request.jira_keys", []string{"TEST", "XXX"})
+
+	// Manually build the options as the code does
+	prOptions := struct {
+		Path   string
+		Styles []string
+		Keys   []string
+	}{
+		Path:   ".",
+		Styles: []string{},
+		Keys:   []string{},
+	}
+
+	if viper.IsSet("pull_request.jira_title") {
+		prOptions.Styles = append(prOptions.Styles, "jira")
+		prOptions.Keys = viper.GetStringSlice("pull_request.jira_keys")
+	}
+
+	if viper.IsSet("pull_request.conventional") {
+		prOptions.Styles = append(prOptions.Styles, "conventional")
+	}
+
+	// Verify both styles are present
+	assert.Equal(t, 2, len(prOptions.Styles))
+	assert.Contains(t, prOptions.Styles, "jira")
+	assert.Contains(t, prOptions.Styles, "conventional")
+	assert.Equal(t, []string{"TEST", "XXX"}, prOptions.Keys)
+
+	viper.Reset()
+}


### PR DESCRIPTION
Closes #565 
<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Support multiple PR title styles (Conventional and JIRA) in `prpipeline` with updated validation and tests.
> 
>   - **Behavior**:
>     - `Options` struct in `pipeline.go` now supports multiple PR title styles via `Styles []PRStyle`.
>     - `validateTitle()` in `run.go` updated to validate against multiple styles, returning combined success or error messages.
>   - **Tests**:
>     - Added `run_test.go` to test various combinations of Conventional and JIRA styles, including both success and failure cases.
>     - Updated `run_test.go` in `root_runner` to verify pipeline creation with different style configurations.
>   - **Misc**:
>     - Updated `Run()` in `root_runner/run.go` to append multiple styles to `prOptions.Styles` based on configuration.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=aevea%2Fcommitsar&utm_source=github&utm_medium=referral)<sup> for 2229b49bce422f54d8712df6bf5b1f744a418b04. You can [customize](https://app.ellipsis.dev/aevea/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->